### PR TITLE
Make sure the correct user id is passed when selecting the identifier for the backend view

### DIFF
--- a/src/plugins/system/id4me/id4me.php
+++ b/src/plugins/system/id4me/id4me.php
@@ -369,7 +369,7 @@ class PlgSystemId4me extends CMSPlugin
 		$query = $this->db->getQuery(true)
 			->select($this->db->quoteName(['profile_value']))
 			->from('#__user_profiles')
-			->where($this->db->quoteName('user_id') . ' = ' . Factory::getUser()->id)
+			->where($this->db->quoteName('user_id') . ' = ' . $this->db->quote($data->id))
 			->where($this->db->quoteName('profile_key') . ' = ' . $this->db->quote('id4me.identifier'));
 
 		$this->db->setQuery($query);


### PR DESCRIPTION
Make sure the correct user id is passed when selecting the identifier for the backend view

ATM we use the current logged in user-id but we should use the ID of the user we are about to check :)